### PR TITLE
Improves moving multiple selected elements and fixed bug with connector labels

### DIFF
--- a/gwt-connectors/src/main/java/pl/tecna/gwt/connectors/client/drag/ShapePickupDragController.java
+++ b/gwt-connectors/src/main/java/pl/tecna/gwt/connectors/client/drag/ShapePickupDragController.java
@@ -130,9 +130,7 @@ public class ShapePickupDragController extends PickupDragController {
         for (ConnectionPoint cp : shape.connectionPoints) {
           for (EndPoint ep : cp.gluedEndPoints) {
             if (diagram.ctrlPressed) {
-              ep.setPosition(cp.getConnectionPositionLeft(), cp.getConnectionPositionTop());
-              ep.connector.calculateStandardPointsPositions();
-              ep.connector.drawSections();
+              moveEndPointGluedToCP(ep, cp);
             } else if (diagram.shiftPressed || (ep.connector.sections.size() <= 3 && !ep.connector.keepShape)) {
               if (diagram.shiftPressed) { 
                 ep.connector.keepShape = false;
@@ -145,9 +143,7 @@ public class ShapePickupDragController extends PickupDragController {
                   && context.selectedWidgets.contains(ep.connector.startEndPoint.gluedConnectionPoint.getParentShape())
                   && context.selectedWidgets.contains(ep.connector.endEndPoint.gluedConnectionPoint.getParentShape())) {
 
-                ep.connector.moveOffsetFromStartPos(context.desiredDraggableX - startX
-                    - diagram.boundaryPanel.getAbsoluteLeft(), context.desiredDraggableY - startY
-                    - diagram.boundaryPanel.getAbsoluteTop());
+                moveEndPointGluedToCP(ep, cp);
               } else {
                 // one element selected
                 boolean vertical = false;
@@ -194,6 +190,15 @@ public class ShapePickupDragController extends PickupDragController {
 
     dragableWidgets.remove(draggable);
     super.makeNotDraggable(draggable);
+  }
+  
+  /*
+   * Move End Point without change Connection Point's glue position
+   */
+  private void moveEndPointGluedToCP(EndPoint ep, ConnectionPoint cp) {
+    ep.setPosition(cp.getConnectionPositionLeft(), cp.getConnectionPositionTop());
+    ep.connector.calculateStandardPointsPositions();
+    ep.connector.drawSections();
   }
 
   private void recreateConnectios(Connector conn) {

--- a/gwt-connectors/src/main/java/pl/tecna/gwt/connectors/client/elements/EndPoint.java
+++ b/gwt-connectors/src/main/java/pl/tecna/gwt/connectors/client/elements/EndPoint.java
@@ -186,7 +186,7 @@ public class EndPoint extends Point {
   }
   
   public void moveLinkedShape(Integer offsetLeft, Integer offsetTop) {
-    if (linkedShape != null && linkedShape.isAttached()) {
+    if (linkedShape != null && linkedShape.isAttached() && linkedShape.diagram.boundaryPanel.equals(linkedShape.getParent())) {
       WidgetLocation linkedShapeLocation = new WidgetLocation(linkedShape, linkedShape.diagram.boundaryPanel);
       linkedShape.left = linkedShapeLocation.getLeft() + offsetLeft;
       linkedShape.top = linkedShapeLocation.getTop() + offsetTop;


### PR DESCRIPTION
Fixed bug with drag shapes with linked connector labels in multiselection.
Set CTRL method as default for moving multiple selected elements.
