### PR TITLE
Removed unnecessary resources annotation in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,14 +72,6 @@
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
 			</resource>
-			<resource>
-				<directory>src/main/java</directory>
-				<includes>
-					<include>**/client/**</include>
-					<include>**/shared/**</include>
-					<include>**/*.gwt.xml</include>
-				</includes>
-			</resource>
 		</resources>
 
 		<plugins>


### PR DESCRIPTION
By default, Maven looks for project's resources under _/src/main/resources_. It's also possible to specify additional directories by changing the _pom.xml_ configuration file. With the current configuration, the files from the _/src/main/java_ (which are the source files) are also considered as resources, if they satisfy the criteria provided in _\<includes/\>_ nodes (so, in the case, they must be either in _client_ or _shared_ folder, or be a module XML file, i.e. the _.gwt.xml_ file.

When working in SuperDev Mode, changes made in one of the resources files don't trigger the compilation of the sources (because, as the name suggests, it's relevant to sources only). This behaviour can be confirmed in Maven's log output (see the screenshot below).

![image](https://user-images.githubusercontent.com/8102102/67009065-1b72cd00-f0eb-11e9-8446-d4a5a095e926.png)

This pull request removes unnecessary resource annotation, thus making the changes in code source visible to compiler again.

![image](https://user-images.githubusercontent.com/8102102/67009098-2c234300-f0eb-11e9-8122-2c57c9f09033.png)

It may be necessary to remove the _target_ directory by running _mvn clean_ in order for this fix to start working.